### PR TITLE
Added skip_exceptions option

### DIFF
--- a/runipy/main.py
+++ b/runipy/main.py
@@ -29,6 +29,8 @@ def main():
             help='output an HTML snapshot of the notebook')
     parser.add_argument('--pylab', action='store_true',
             help='start notebook with pylab enabled')
+    parser.add_argument('--skip-exceptions', '-s', action='store_true',
+            help='if an exception occurs in a cell, continue running the subsequent cells')
     args = parser.parse_args()
 
 
@@ -48,7 +50,7 @@ def main():
 
     exit_status = 0
     try:
-        nb_runner.run_notebook()
+        nb_runner.run_notebook(skip_exceptions=args.skip_exceptions)
     except NotebookError:
         exit_status = 1
 

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -103,7 +103,7 @@ class NotebookRunner(object):
                         attr = self.MIME_MAP[mime]
                     except KeyError:
                         raise NotImplementedError('unhandled mime type: %s' % mime)
-                    
+
                     setattr(out, attr, data)
                 print(data, end='')
             elif msg_type == 'pyerr':
@@ -130,16 +130,21 @@ class NotebookRunner(object):
                     yield cell
 
 
-    def run_notebook(self):
+    def run_notebook(self, skip_exceptions=False):
         '''
         Run all the cells of a notebook in order and update
         the outputs in-place.
+
+        If ``skip_exceptions`` is set, then if exceptions occur in a cell, the
+        subsequent cells are run (by default, the notebook execution stops).
         '''
         for cell in self.iter_code_cells():
-            self.run_cell(cell)
+            try:
+                self.run_cell(cell)
+            except NotebookError:
+                if not skip_exceptions:
+                    raise
 
-    
     def save_notebook(self, nb_out):
         logging.info('Saving to %s', nb_out)
         write(self.nb, open(nb_out, 'w'), 'json')
-


### PR DESCRIPTION
This adds a `--skip-exceptions` option that allows a notebook to continue to run even if a cell raises an exception. I often include examples in notebooks that raise exceptions (to demonstrate something to students) so exceptions are expected in my case. I'm open to a better name for this option :)
