### PR TITLE
Add instructions for running runipy from Python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,8 @@ The easiest way to install ``runipy`` is with ``pip``::
 
     $ pip install runipy
 
-Use
----
+Command-line use
+----------------
 
 To run a ``.ipynb`` file as a script, run::
 
@@ -39,6 +39,20 @@ To save the notebook output as a *new* notebook, run::
 To run a ``.ipynb`` file and genereate an ``HTML`` report, run::
 
     $ runipy MyNotebook.ipynb --html report.html
+
+Programmatic use
+----------------
+
+It is also possible to run IPython notebooks from Python, using::
+
+    from runipy.notebook_runner import NotebookRunner
+
+    r = NotebookRunner("MyNotebook.ipynb")
+    r.run_notebook()
+
+and you can enable ``pylab`` with::
+
+    r = NotebookRunner("MyNotebook.ipynb", pylab=True)
 
 Credit
 ------

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -32,7 +32,7 @@ class NotebookRunner(object):
         'text/latex': 'latex',
     }
 
-    def __init__(self, nb_in, pylab):
+    def __init__(self, nb_in, pylab=False):
         km = KernelManager()
         if pylab:
             km.start_kernel(extra_arguments=['--pylab=inline'])


### PR DESCRIPTION
This is just an idea in case you are interested - I need to run many notebooks automatically, and am doing so from Python, so I decided to try and use it programmatically. This adds instructions to the README.rst for how to do this and also makes a minor change so that `pylab` doesn't have to be given in `__init__` if `False` (which is default also for the command-line).

The only issue with this is that the logger doesn't get set up this way, but there is probably a solution to this?
