### PR TITLE
Allow --matplotlib=inline instead of --pylab=inline

### DIFF
--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -33,10 +33,12 @@ class NotebookRunner(object):
         'application/javascript': 'html',
     }
 
-    def __init__(self, nb_in, pylab=False):
+    def __init__(self, nb_in, pylab=False, mpl_inline=False):
         self.km = KernelManager()
         if pylab:
             self.km.start_kernel(extra_arguments=['--pylab=inline'])
+        elif mpl_inline:
+            self.km.start_kernel(extra_arguments=['--matplotlib=inline'])
         else:
             self.km.start_kernel()
 


### PR DESCRIPTION
The ipython devs discourage the use of pylab now (https://github.com/ipython/ipython/pull/5066), so it would be nice to have an option that allows inline plotting _without_ including the pylab environment.
