### PR TITLE
Added the ability to pass nb in as a buffer

### DIFF
--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -33,7 +33,7 @@ class NotebookRunner(object):
         'application/javascript': 'html',
     }
 
-    def __init__(self, nb_in, pylab=False, mpl_inline=False):
+    def __init__(self, nb_in=None, pylab=False, mpl_inline=False, nb=None):
         self.km = KernelManager()
         if pylab:
             self.km.start_kernel(extra_arguments=['--pylab=inline'])
@@ -57,7 +57,11 @@ class NotebookRunner(object):
         self.iopub = self.kc.iopub_channel
 
         logging.info('Reading notebook %s', nb_in)
-        self.nb = read(open(nb_in), 'json')
+        
+        self.nb = nb
+        
+        if not self.nb:
+            self.nb = read(open(nb_in), 'json')
 
     def __del__(self):
         self.kc.stop_channels()


### PR DESCRIPTION
I have a use case where I need to pass in a buffer object instead of a string that opens a file (so I can read a notebook from a Django file object). I made a simple backwards compatible change to the constructor that allows for passing a nb buffer directly instead of a file path.
