### PR TITLE
Avoid mangling traceback ANSI formatting.

### DIFF
--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -75,7 +75,9 @@ class NotebookRunner(object):
         reply = self.shell.get_msg()
         status = reply['content']['status']
         if status == 'error':
-            logging.info('Cell raised uncaught exception: \n%s', '\n'.join(reply['content']['traceback']))
+            traceback_text = 'Cell raised uncaught exception: \n' + \
+                '\n'.join(reply['content']['traceback'])
+            logging.info(traceback_text)
         else:
             logging.info('Cell returned')
 
@@ -127,7 +129,7 @@ class NotebookRunner(object):
         cell['outputs'] = outs
 
         if status == 'error':
-            raise NotebookError()
+            raise NotebookError(traceback_text)
 
 
     def iter_code_cells(self):


### PR DESCRIPTION
The use of `%s` formatting breaks the ANSI color and formatting IPython annotates the traceback with.  This change preserves the formatting, making it once again possible to easily view tracebacks raised by a notebook run by runipy.

I've also saved the traceback text and pass it as an argument to NotebookError, making it easier to communicate the nature of the error to the calling function.
