### PR TITLE
Explains how to save the notebook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,11 @@ It is also possible to run IPython notebooks from Python, using::
 and you can enable ``pylab`` with::
 
     r = NotebookRunner(notebook, pylab=True)
+    
+The notebook is stored in the object and can be saved using::
+
+    from IPython.nbformat.current import write
+    write(r.nb, open("MyOtherNotebook.ipynb", 'w'), 'json')
 
 Credit
 ------


### PR DESCRIPTION
There was no explanation of how to save the notebook after running it form inside a python script. I looked inside the code and found how to do it. Thus, I thought that it would be a good idea to put it in the README.
