### PR TITLE
Add a per cell callback on run_notebook

### DIFF
--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -167,7 +167,7 @@ class NotebookRunner(object):
                     yield cell
 
 
-    def run_notebook(self, skip_exceptions=False):
+    def run_notebook(self, skip_exceptions=False, execute_cell_no_callback=None):
         '''
         Run all the cells of a notebook in order and update
         the outputs in-place.
@@ -175,10 +175,21 @@ class NotebookRunner(object):
         If ``skip_exceptions`` is set, then if exceptions occur in a cell, the
         subsequent cells are run (by default, the notebook execution stops).
         '''
-        for cell in self.iter_code_cells():
+        for n, cell in enumerate( self.iter_code_cells() ):
             try:
                 self.run_cell(cell)
             except NotebookError:
                 if not skip_exceptions:
                     raise
+            if execute_cell_no_callback:
+                execute_cell_no_callback(n)
 
+
+    def count_code_cells(self):
+        '''
+        Return the number of code cells in the notebook
+        '''
+        for n, cell in enumerate( self.iter_code_cells() ):
+            pass
+        return n
+        


### PR DESCRIPTION
When using the API it is useful to know the progress of cell
execution (e.g. if running in another thread). This commit adds the
ability to pass a callback function as execute_cell_no_callback that
if set will be called with the current cell number.

An additional helper function is added to NotebookRunner that returns
the number of code cells in the current set workbook. Combined with
the callback this can be used to calculate a % progress.
