### PR TITLE
Allow --profile-dir argument

### DIFF
--- a/runipy/main.py
+++ b/runipy/main.py
@@ -42,6 +42,8 @@ def main():
             help='read notebook from stdin (or use - as input_file)')
     parser.add_argument('--no-chdir', action='store_true',
             help="do not change directory to notebook's at kernel startup")
+    parser.add_argument('--profile-dir',
+            help="set the profile location directly")
     args = parser.parse_args()
 
 
@@ -74,7 +76,7 @@ def main():
 
     logging.info('Reading notebook %s', payload.name)
     nb = read(payload, 'json')
-    nb_runner = NotebookRunner(nb, args.pylab, args.matplotlib, working_dir)
+    nb_runner = NotebookRunner(nb, args.pylab, args.matplotlib, args.profile_dir, working_dir)
 
     exit_status = 0
     try:

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -36,7 +36,7 @@ class NotebookRunner(object):
     }
 
 
-    def __init__(self, nb, pylab=False, mpl_inline=False, working_dir = None):
+    def __init__(self, nb, pylab=False, mpl_inline=False, profile_dir=None, working_dir=None):
         self.km = KernelManager()
 
         args = []
@@ -47,6 +47,9 @@ class NotebookRunner(object):
         elif mpl_inline:
             args.append('--matplotlib=inline')
             logging.warn('--matplotlib is deprecated and will be removed in a future version')
+
+        if profile_dir:
+            args.append('--profile-dir=%s' % os.path.abspath(profile_dir))
 
         cwd = os.getcwd()
 


### PR DESCRIPTION
Ref #38

This patch enables --profile-dir argument for IPython

ex.
```
runipy --profile-dir=./profile notebook_root/mybook.ipynb
```