### PR TITLE
explicit shutdown of kernel; fixed typo in html filename

### DIFF
--- a/runipy/main.py
+++ b/runipy/main.py
@@ -98,7 +98,7 @@ def main():
             if args.input_file.endswith('.ipynb'):
                 args.html = args.input_file[:-6] + '.html'
             else:
-                args.html = args.input_file + '.ipynb'
+                args.html = args.input_file + '.html'
 
         if args.template is False:
             exporter = HTMLExporter()
@@ -109,6 +109,8 @@ def main():
         logging.info('Saving HTML snapshot to %s' % args.html)
         output, resources = exporter.from_notebook_node(nb_runner.nb)
         codecs.open(args.html, 'w', encoding='utf-8').write(output)
+
+    nb_runner.shutdown_kernel()
 
     if exit_status != 0:
         logging.warning('Exiting with nonzero exit status')

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -74,7 +74,8 @@ class NotebookRunner(object):
         self.nb = nb
         
 
-    def __del__(self):
+    def shutdown_kernel(self):
+        logging.info('Shutdown kernel')
         self.kc.stop_channels()
         self.km.shutdown_kernel(now=True)
 


### PR DESCRIPTION
This should address the issue with application not exiting with --html option.