### PR TITLE
Fix the use of a template with latest IPython.

### DIFF
--- a/runipy/main.py
+++ b/runipy/main.py
@@ -104,7 +104,7 @@ def main():
             exporter = HTMLExporter()
         else:
             exporter = HTMLExporter(
-                    config=Config({'HTMLExporter':{'default_template':args.template}}))
+                    config=Config({'HTMLExporter':{'template_file':args.template}}))
 
         logging.info('Saving HTML snapshot to %s' % args.html)
         output, resources = exporter.from_notebook_node(nb_runner.nb)


### PR DESCRIPTION
The use of a template wasn't working for me with IPython 2.3.1. After some digging in runipy and IPython's codes, I found this solution to fix my issue but I have no idea of what the best fix is. Maybe for compatibility it would ok to set both values, something like
```python
config=Config({'HTMLExporter': {
    'default_template': args.template,
    'template_file': args.template,
}}))
```