### PR TITLE
Nbformat.current is deprecated

### DIFF
--- a/runipy/main.py
+++ b/runipy/main.py
@@ -8,7 +8,12 @@ import codecs
 import runipy
 
 from runipy.notebook_runner import NotebookRunner, NotebookError
-from IPython.nbformat.current import read, write
+try:
+    # IPython 3
+    from IPython.nbformat import read, write, NBFormatError
+except ImportError:
+    # IPython 2
+    from IPython.nbformat.current import read, write, NBFormatError
 
 from IPython.config import Config
 from IPython.nbconvert.exporters.html import HTMLExporter
@@ -114,7 +119,12 @@ def main():
         profile_dir = None
 
     logging.info('Reading notebook %s', payload.name)
-    nb = read(payload, 'json')
+    try:
+        # Ipython 3
+        nb = read(payload, 3)
+    except (TypeError, NBFormatError):
+        # Ipython 2
+        nb = read(payload, 'json')
     nb_runner = NotebookRunner(
         nb, args.pylab, args.matplotlib, profile_dir, working_dir
     )

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -12,7 +12,11 @@ from time import sleep
 import logging
 import os
 
-from IPython.nbformat.current import NotebookNode
+try:
+    # IPython 3
+    from IPython.nbformat import NotebookNode
+except ImportError:
+    from IPython.nbformat.current import NotebookNode
 from IPython.kernel import KernelManager
 
 

--- a/test_runipy.py
+++ b/test_runipy.py
@@ -5,7 +5,12 @@ from glob import glob
 from os import path
 import re
 
-from IPython.nbformat.current import read
+try:
+    # IPython 3
+    from IPython.nbformat import read, NBFormatError
+except ImportError:
+    # IPython 2
+    from IPython.nbformat.current import read, NBFormatError
 
 from runipy.notebook_runner import NotebookRunner
 
@@ -61,13 +66,25 @@ class TestRunipy(unittest.TestCase):
             print(notebook_file)
             expected_file = path.join('tests', 'expected', notebook_file)
             notebook = ""
-            with open(notebook_path) as notebook_file:
-                notebook = read(notebook_file, 'json')
+            try:
+                # IPython 3
+                with open(notebook_path) as notebook_file:
+                    notebook = read(notebook_file, 3)
+            except (TypeError, NBFormatError):
+                # IPython 2
+                with open(notebook_path) as notebook_file:
+                    notebook = read(notebook_file, 'json')
             runner = NotebookRunner(notebook, working_dir=notebook_dir)
             runner.run_notebook(True)
             expected = ""
-            with open(expected_file) as notebook_file:
-                expected = read(notebook_file, 'json')
+            try:
+                # IPython 3
+                with open(expected_file) as notebook_file:
+                    expected = read(notebook_file, 3)
+            except (TypeError, NBFormatError):
+                # IPython 2
+                with open(expected_file) as notebook_file:
+                    expected = read(notebook_file, 'json')
             self.assert_notebooks_equal(expected, runner.nb)
 
 


### PR DESCRIPTION
This fix the warning that is thrown when `runipy` is loaded.

The version of the notebook changed to 4 with IPython 3.0.0. The format of the previous notebook and this new one is different. When the user is using IPython 3.0, `runipy` will load the notebook as version 3 and not 4. I think this PR can help on this.