### PR TITLE
Add a --check-outputs flag

### DIFF
--- a/runipy/main.py
+++ b/runipy/main.py
@@ -6,11 +6,11 @@ from sys import stderr, stdout, stdin, exit
 import os.path
 import logging
 import codecs
+
 import runipy
-
 from runipy.notebook_runner import NotebookRunner, NotebookError
-from IPython.nbformat.current import read, write
 
+from IPython.nbformat.current import read, write
 from IPython.config import Config
 from IPython.nbconvert.exporters.html import HTMLExporter
 

--- a/runipy/testbase.py
+++ b/runipy/testbase.py
@@ -1,0 +1,36 @@
+
+import unittest
+import re
+
+class TestRunipyBase(unittest.TestCase):
+    maxDiff = 100000
+
+    def prepare_cell(self, cell):
+        cell = dict(cell)
+        if 'metadata' in cell:
+            del cell['metadata']
+        if 'text' in cell:
+            # don't match object's id; also happens to fix incompatible
+            # results between IPython2 and IPython3 (which prints "object" instead
+            # of "at [id]"
+            cell['text'] = re.sub('at 0x[0-9a-f]{7,9}', 'object', cell['text'])
+        if 'traceback' in cell:
+            cell['traceback'] = [re.sub('\x1b\\[[01];\\d\\dm', '', line) for line in cell['traceback']]
+            # rejoin lines, so it's one string to compare
+            cell['traceback'] = u'\n'.join(cell['traceback'])
+        return cell
+
+
+    def assert_notebooks_equal(self, expected, actual):
+        self.assertEquals(len(expected['worksheets'][0]['cells']),
+                len(actual['worksheets'][0]['cells']))
+
+        for expected_out, actual_out in zip(expected['worksheets'][0]['cells'],
+                actual['worksheets'][0]['cells']):
+            for k in set(expected_out).union(actual_out):
+                if k == 'outputs':
+                    self.assertEquals(len(expected_out[k]), len(actual_out[k]))
+                    for e, a in zip(expected_out[k], actual_out[k]):
+                        e = self.prepare_cell(e)
+                        a = self.prepare_cell(a)
+                        self.assertEquals(a, e)

--- a/test.py
+++ b/test.py
@@ -2,45 +2,13 @@
 import unittest
 from glob import glob
 from os import path, chdir
-import re
 
 from IPython.nbformat.current import read
 
 from runipy.notebook_runner import NotebookRunner
+from runipy.testbase import TestRunipyBase
 
-class TestRunipy(unittest.TestCase):
-    maxDiff = 100000
-
-    def prepare_cell(self, cell):
-        cell = dict(cell)
-        if 'metadata' in cell:
-            del cell['metadata']
-        if 'text' in cell:
-            # don't match object's id; also happens to fix incompatible
-            # results between IPython2 and IPython3 (which prints "object" instead
-            # of "at [id]"
-            cell['text'] = re.sub('at 0x[0-9a-f]{7,9}', 'object', cell['text'])
-        if 'traceback' in cell:
-            cell['traceback'] = [re.sub('\x1b\\[[01];\\d\\dm', '', line) for line in cell['traceback']]
-            # rejoin lines, so it's one string to compare
-            cell['traceback'] = u'\n'.join(cell['traceback'])
-        return cell
-
-
-    def assert_notebooks_equal(self, expected, actual):
-        self.assertEquals(len(expected['worksheets'][0]['cells']),
-                len(actual['worksheets'][0]['cells']))
-
-        for expected_out, actual_out in zip(expected['worksheets'][0]['cells'],
-                actual['worksheets'][0]['cells']):
-            for k in set(expected_out).union(actual_out):
-                if k == 'outputs':
-                    self.assertEquals(len(expected_out[k]), len(actual_out[k]))
-                    for e, a in zip(expected_out[k], actual_out[k]):
-                        e = self.prepare_cell(e)
-                        a = self.prepare_cell(a)
-                        self.assertEquals(a, e)
-                    
+class TestRunipy(TestRunipyBase):
 
     def testRunNotebooks(self):
         notebook_dir = path.join('tests', 'input')


### PR DESCRIPTION
Hello,

As [discussed](http://python.6.x6.nabble.com/status-of-ipnbdoctest-py-td5080999.html) some month ago, this is proposal to add the possibilty to verify cell output isn't changing when running a notebook.

This add a `--check-outputs` flag.

Comments welcome...
