### PR TITLE
Added kernel option + rst export + other stuff

### DIFF
--- a/runipy/main.py
+++ b/runipy/main.py
@@ -34,7 +34,7 @@ def main():
             help='turn on debug messages')
     parser.add_argument('--kernel', default=None,
             help="choose kernel (python2, python3, julia-0.3, julia-0.4, ...")
-    parser.add_argument('--port', default=8888,
+    parser.add_argument('--port', default=None,
             help="choose port number for kernel")
     parser.add_argument('--overwrite', '-o', action='store_true',
             help='write notebook output back to original notebook')

--- a/runipy/main.py
+++ b/runipy/main.py
@@ -32,6 +32,8 @@ def main():
             help='don\'t print anything unless things go wrong')
     parser.add_argument('--kernel', default=None,
             help="choose kernel (python2, python3, julia-0.3, julia-0.4, ...")
+    parser.add_argument('--port', default=8888,
+            help="choose port number for kernel")
     parser.add_argument('--overwrite', '-o', action='store_true',
             help='write notebook output back to original notebook')
     parser.add_argument('--html', nargs='?', default=False,
@@ -105,7 +107,7 @@ def run_notebook(args):
 
     logging.info('Reading notebook %s', payload.name)
     nb = read(payload, 'json')
-    nb_runner = NotebookRunner(nb, args.pylab, args.matplotlib, profile_dir, working_dir, kernel=args.kernel)
+    nb_runner = NotebookRunner(nb, args.pylab, args.matplotlib, profile_dir, working_dir, kernel=args.kernel, port=args.port)
 
     exit_status = 0
     try:

--- a/runipy/main.py
+++ b/runipy/main.py
@@ -27,6 +27,8 @@ def main():
             help='.ipynb file to save cell output to')
     parser.add_argument('--quiet', '-q', action='store_true',
             help='don\'t print anything unless things go wrong')
+    parser.add_argument('--kernel', default=None,
+            help="choose kernel (python2, python3, julia-0.3, julia-0.4, ...")
     parser.add_argument('--overwrite', '-o', action='store_true',
             help='write notebook output back to original notebook')
     parser.add_argument('--html', nargs='?', default=False,
@@ -84,7 +86,7 @@ def main():
 
     logging.info('Reading notebook %s', payload.name)
     nb = read(payload, 'json')
-    nb_runner = NotebookRunner(nb, args.pylab, args.matplotlib, profile_dir, working_dir)
+    nb_runner = NotebookRunner(nb, args.pylab, args.matplotlib, profile_dir, working_dir, kernel=args.kernel)
 
     exit_status = 0
     try:

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -14,6 +14,7 @@ import os
 
 from IPython.nbformat.current import NotebookNode
 from IPython.kernel import KernelManager
+from IPython.kernel.kernelspec import KernelSpecManager
 
 
 class NotebookError(Exception):
@@ -36,7 +37,7 @@ class NotebookRunner(object):
     }
 
 
-    def __init__(self, nb, pylab=False, mpl_inline=False, profile_dir=None, working_dir=None):
+    def __init__(self, nb, pylab=False, mpl_inline=False, profile_dir=None, working_dir=None, kernel=None):
         self.km = KernelManager()
 
         args = []
@@ -55,6 +56,15 @@ class NotebookRunner(object):
 
         if working_dir:
             os.chdir(working_dir)
+
+        if kernel is not None:
+            logging.info("Starting {0} kernel".format(kernel))
+            ksm = KernelSpecManager()
+            kernel_specs = ksm.find_kernel_specs()
+            if not kernel in kernel_specs:
+                logging.info("Installed kernels: {0}".format(', '.join(kernel_specs)))
+            # throws NoSuchKernel when not found
+            self.km.kernel_spec = ksm.get_kernel_spec(kernel)
 
         self.km.start_kernel(extra_arguments = args)
         

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -37,7 +37,7 @@ class NotebookRunner(object):
     }
 
 
-    def __init__(self, nb, pylab=False, mpl_inline=False, profile_dir=None, working_dir=None, kernel=None):
+    def __init__(self, nb, pylab=False, mpl_inline=False, profile_dir=None, working_dir=None, kernel=None, port=8888):
         self.km = KernelManager()
 
         args = []
@@ -66,7 +66,7 @@ class NotebookRunner(object):
             # throws NoSuchKernel when not found
             self.km.kernel_spec = ksm.get_kernel_spec(kernel)
 
-        self.km.start_kernel(extra_arguments = args)
+        self.km.start_kernel(extra_arguments=args, port=port)
         
         os.chdir(cwd)
 

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -37,7 +37,7 @@ class NotebookRunner(object):
     }
 
 
-    def __init__(self, nb, pylab=False, mpl_inline=False, profile_dir=None, working_dir=None, kernel=None, port=8888):
+    def __init__(self, nb, pylab=False, mpl_inline=False, profile_dir=None, working_dir=None, kernel=None, port=None):
         self.km = KernelManager()
 
         args = []
@@ -66,9 +66,10 @@ class NotebookRunner(object):
             # throws NoSuchKernel when not found
             self.km.kernel_spec = ksm.get_kernel_spec(kernel)
 
-        args.append('--port={0}'.format(port))
-
-        self.km.start_kernel(extra_arguments=args)
+        if port is None:
+            self.km.start_kernel(extra_arguments=args)
+        else:
+            self.km.start_kernel(extra_arguments=args, port=port)
         
         os.chdir(cwd)
 

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -66,7 +66,9 @@ class NotebookRunner(object):
             # throws NoSuchKernel when not found
             self.km.kernel_spec = ksm.get_kernel_spec(kernel)
 
-        self.km.start_kernel(extra_arguments=args, port=port)
+        args.append('--port={0}'.format(port))
+
+        self.km.start_kernel(extra_arguments=args)
         
         os.chdir(cwd)
 


### PR DESCRIPTION
- user can change kernel using --kernel=<kernel>. Valid options are python2, python3, julia-0.3, julia-0.4 etc.. List of proper kernel names is given if mistyped.
- user can export notebook to .rst format using --rst=file.md, syntax is identical to --html. For some reason this is not working for my setup (or to be specific, it works as well as exporting to --html), exception is rised. I suspect that there's something wrong in IPython, not in runipy? Anyway these export options are not working at the moment at least for me.
- splitted main function to "parser" part and "run_notebook" part. Idea is here that user can import package, define his own "args" and use notebook conversion inside own scripts.

Exporting to rst is basically copy-paste from export to html so I think it should be good. After checking IPython sources I think it's valid syntax to call exporter internally. Problems is that IPython raises AttributeError because nb.cells is not defined.
