### PR TITLE
Exclude iPython 4.x (not yet supported)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='runipy',
       install_requires=[
           'Jinja2>=2.7.2',
           'Pygments>=1.6',
-          'ipython>=2.3.1',
+          'ipython>=2.3.1,<4',
           'pyzmq>=14.1.0',
       ],
       packages=['runipy'],


### PR DESCRIPTION
Requires this ( https://github.com/paulgb/runipy/pull/66 ) to be merged first.

As iPython 4.x is not currently supported, this excludes that version of iPython when installing.