### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ install:
    - conda config --set show_channel_urls True
    - source activate root
    - conda update --all
+   # Fix root environment to have the correct Python version.
+   - touch $HOME/miniconda/conda-meta/pinned
+   - echo "python ${PYTHON_VERSION}.*" >> $HOME/miniconda/conda-meta/pinned
+   - conda install python=$PYTHON_VERSION
    # Install basic conda dependencies.
    - touch $HOME/miniconda/conda-meta/pinned
    - echo "conda-build ==1.16.0" >> $HOME/miniconda/conda-meta/pinned

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ install:
    - echo "ipython ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - echo "ipython-notebook ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install ipython-notebook
-   - conda install numpy scipy matplotlib h5py
    # Install runipy.
    - python setup.py install
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,15 @@ install:
    - echo $VERSION
    # Create the test environment and install dependencies.
    - conda create --use-local -n testenv python=$PYTHON_VERSION
+   - source activate testenv
+   # Install dependencies.
    - touch $HOME/miniconda/envs/testenv/conda-meta/pinned
    - echo "ipython ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - echo "ipython-notebook ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
-   - python setup.py install
-   - source activate testenv
-   # Install other dependencies.
+   - conda install ipython-notebook
    - conda install numpy scipy matplotlib h5py
+   # Install runipy.
+   - python setup.py install
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.
    - echo "coverage 3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
    - pwd
 install:
    # Download and configure conda.
-   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+   - wget http://repo.continuum.io/miniconda/Miniconda`echo ${PYTHON_VERSION:0:1} | grep 3`-latest-Linux-x86_64.sh -O miniconda.sh
    - bash miniconda.sh -b -p $HOME/miniconda
    - export PATH="$HOME/miniconda/bin:$PATH"
    - conda config --set always_yes yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
    - "3.4"
    - "3.3"
    - "2.7"
+env:
+   - IPYTHON_VERSION=3
+   - IPYTHON_VERSION=2
 before_install:
    # Move out of git directory to build root.
    - deactivate
@@ -28,7 +31,11 @@ install:
    - echo $VERSION
    - python setup.py bdist_conda
    # Create the test environment and install dependencies.
-   - conda create --use-local -n testenv python=$TRAVIS_PYTHON_VERSION runipy==$VERSION
+   - conda create --use-local -n testenv python=$TRAVIS_PYTHON_VERSION
+   - touch $HOME/miniconda/envs/testenv/conda-meta/pinned
+   - echo "ipython ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
+   - echo "ipython-notebook ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
+   - conda install --use-local -n testenv runipy==$VERSION
    - source activate testenv
    # Install other dependencies.
    - conda install numpy scipy matplotlib h5py

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
    - source activate testenv
    # Install dependencies.
    - touch $HOME/miniconda/envs/testenv/conda-meta/pinned
+   - echo "python ${PYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - echo "ipython ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - echo "ipython-notebook ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install ipython-notebook

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ install:
    - conda config --set show_channel_urls True
    - source activate root
    # Install basic conda dependencies.
+   - touch $HOME/miniconda/conda-meta/pinned
+   - echo "conda-build ==1.16.0" >> $HOME/miniconda/conda-meta/pinned
    - conda update --all
    - conda install conda-build
    # Build the conda package for runipy.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
-language: python
-python:
-   - "3.5.0b4"
-   - "3.4"
-   - "3.3"
-   - "2.7"
+language: cpp
 env:
-   - IPYTHON_VERSION=3
-   - IPYTHON_VERSION=2
+   - PYTHON_VERSION="3.4" IPYTHON_VERSION=3
+   - PYTHON_VERSION="3.3" IPYTHON_VERSION=3
+   - PYTHON_VERSION="2.7" IPYTHON_VERSION=3
+   - PYTHON_VERSION="3.3" IPYTHON_VERSION=2
+   - PYTHON_VERSION="2.7" IPYTHON_VERSION=2
 before_install:
    # Move out of git directory to build root.
-   - deactivate
    - cd ../..
    - pwd
 install:
@@ -31,7 +28,7 @@ install:
    - echo $VERSION
    - python setup.py bdist_conda
    # Create the test environment and install dependencies.
-   - conda create --use-local -n testenv python=$TRAVIS_PYTHON_VERSION
+   - conda create --use-local -n testenv python=$PYTHON_VERSION
    - touch $HOME/miniconda/envs/testenv/conda-meta/pinned
    - echo "ipython ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - echo "ipython-notebook ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+language: python
+python:
+   - "2.7"
+before_install:
+   # Move out of git directory to build root.
+   - deactivate
+   - cd ../..
+   - pwd
+install:
+   # Download and configure conda.
+   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+   - bash miniconda.sh -b -p $HOME/miniconda
+   - export PATH="$HOME/miniconda/bin:$PATH"
+   - conda config --set always_yes yes
+   - conda config --set show_channel_urls True
+   - source activate root
+   # Install basic conda dependencies.
+   - conda update --all
+   - conda install conda-build
+   # Build the conda package for runipy.
+   - cd $TRAVIS_REPO_SLUG
+   - VERSION=`python setup.py --version`
+   - echo $VERSION
+   - python setup.py bdist_conda
+   # Create the test environment and install dependencies.
+   - conda create --use-local -n testenv python=$TRAVIS_PYTHON_VERSION runipy==$VERSION
+   - source activate testenv
+   # Install other dependencies.
+   - conda install numpy scipy matplotlib h5py
+   # Clean up downloads as there are quite a few and they waste space/memory.
+   - conda clean -tipsy
+   - rm -rfv $HOME/.cache/pip
+script:
+   # Run tests.
+   - python setup.py test --verbose
+# Use container format for TravisCI.
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,15 @@ install:
    - source activate testenv
    # Install other dependencies.
    - conda install numpy scipy matplotlib h5py
+   # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.
+   - echo "coverage 3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
+   - conda install coverage
    # Clean up downloads as there are quite a few and they waste space/memory.
    - conda clean -tipsy
    - rm -rfv $HOME/.cache/pip
 script:
    # Run tests.
-   - python setup.py test --verbose
+   - coverage run setup.py test --verbose
+   - coverage report
 # Use container format for TravisCI.
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 python:
+   - "3.5.0b4"
+   - "3.4"
+   - "3.3"
    - "2.7"
 before_install:
    # Move out of git directory to build root.

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,7 @@ script:
    - coverage report
 # Use container format for TravisCI.
 sudo: false
+notifications:
+  email:
+    on_success: always
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,5 +55,10 @@ script:
 sudo: false
 notifications:
   email:
+    on_success: never
+    on_failure: never
+  webhooks:
     on_success: always
     on_failure: always
+    urls:
+      - https://webhooks.gitter.im/e/ddb94a08ad824369f3bf

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ install:
    - conda config --set always_yes yes
    - conda config --set show_channel_urls True
    - source activate root
+   - conda update --all
    # Install basic conda dependencies.
    - touch $HOME/miniconda/conda-meta/pinned
    - echo "conda-build ==1.16.0" >> $HOME/miniconda/conda-meta/pinned
-   - conda update --all
    - conda install conda-build
    # Build the conda package for runipy.
    - cd $TRAVIS_REPO_SLUG

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,12 @@ install:
    - cd $TRAVIS_REPO_SLUG
    - VERSION=`python setup.py --version`
    - echo $VERSION
-   - python setup.py bdist_conda
    # Create the test environment and install dependencies.
    - conda create --use-local -n testenv python=$PYTHON_VERSION
    - touch $HOME/miniconda/envs/testenv/conda-meta/pinned
    - echo "ipython ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - echo "ipython-notebook ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
-   - conda install --use-local -n testenv runipy==$VERSION
+   - python setup.py install
    - source activate testenv
    # Install other dependencies.
    - conda install numpy scipy matplotlib h5py

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|License| |Version| |Gitter|
+|Travis Build Status| |License| |Version| |Gitter|
 
 --------------
 
@@ -120,6 +120,8 @@ Gustavo Bragança, Tobias Brandt, Andrea Zonca, Aaron O'Leary, Simon Guillot,
 Fernando Correia, Takashi Nishibayashi, Simon Conseil, and Thomas French
 for patches, documentation fixes, and suggestions.
 
+.. |Travis Build Status| image:: https://travis-ci.org/paulgb/runipy.svg?branch=master
+    :target: https://travis-ci.org/paulgb/runipy
 
 .. |License| image:: https://img.shields.io/badge/license-BSD-blue.svg
    :alt: BSD License


### PR DESCRIPTION
* Provides continuous integration for Travis CI.
* Uses conda to install the more unwieldy dependencies (`numpy`, `scipy`, `matplotlib`, `zmq`/`pyzmq`, etc)
* Uses environment variables to allow for testing against different combinations of Python and iPython.
* Ensures that iPython versions are only tested against Python version, which they maintain support against.
* Skips testings against iPython 4 for now.
* Will pass in all environments if the previous two PRs are merged.
* Once merged CI can be enabled on Travis CI with the flick of a switch.
