### PR TITLE
Use coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+branch = True
+erase = True
+package = runipy

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,9 @@ exclude_lines =
     # ( https://bitbucket.org/ned/coveragepy/issue/198/continue-marked-as-not-covered )
     # and Python issue ( http://bugs.python.org/issue2506 ).
     continue
+
+    # Ignore coverage of code that requires the module to be executed.
+    if __name__ == .__main__.:
 omit =
     */python?.?/*
     */site-packages/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,12 @@ branch = True
 erase = True
 package = runipy
 [report]
+exclude_lines =
+    # Ignore continue statement in code as it can't be detected as covered
+    # due to an optimization by the Python interpreter. See coverage issue
+    # ( https://bitbucket.org/ned/coveragepy/issue/198/continue-marked-as-not-covered )
+    # and Python issue ( http://bugs.python.org/issue2506 ).
+    continue
 omit =
     */python?.?/*
     */site-packages/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,10 @@
 branch = True
 erase = True
 package = runipy
+[report]
+omit =
+    */python?.?/*
+    */site-packages/*
+    *tests/*
+    */versioneer.py
+    */_version.py

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ runipy.egg-info
 .*.swp
 build
 dist
+
+.coverage


### PR DESCRIPTION
Provides a `.coveragerc` file to properly determine the behavior for running `coverage` (3.x). Also, excludes the `.coverage` binary file generated after a run. To run tests with `coverage`, simply run `coverage run setup.py test`. A short summary of the test coverage by file can be generated by running `coverage report`.