### PR TITLE
Add coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.
    - echo "coverage 3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install coverage
-   - conda install coveralls
+   - pip install coveralls
    # Clean up downloads as there are quite a few and they waste space/memory.
    - conda clean -tipsy
    - rm -rfv $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ install:
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.
    - echo "coverage 3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install coverage
+   - conda install python-coveralls
    # Clean up downloads as there are quite a few and they waste space/memory.
    - conda clean -tipsy
    - rm -rfv $HOME/.cache/pip
@@ -52,6 +53,9 @@ script:
    - coverage run setup.py test --verbose
    - coverage report
 # Use container format for TravisCI.
+after_success:
+   # Submit results to coveralls.io.
+   - coveralls
 sudo: false
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.
    - echo "coverage 3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install coverage
-   - conda install python-coveralls
+   - conda install coveralls
    # Clean up downloads as there are quite a few and they waste space/memory.
    - conda clean -tipsy
    - rm -rfv $HOME/.cache/pip

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Travis Build Status| |License| |Version| |Gitter|
+|Travis Build Status| |Coveralls| |License| |Version| |Gitter|
 
 --------------
 
@@ -122,6 +122,9 @@ for patches, documentation fixes, and suggestions.
 
 .. |Travis Build Status| image:: https://travis-ci.org/paulgb/runipy.svg?branch=master
     :target: https://travis-ci.org/paulgb/runipy
+
+.. |Coveralls| image:: https://coveralls.io/repos/paulgb/runipy/badge.svg?branch=master&service=github
+  :target: https://coveralls.io/github/paulgb/runipy?branch=master
 
 .. |License| image:: https://img.shields.io/badge/license-BSD-blue.svg
    :alt: BSD License


### PR DESCRIPTION
Merge this first ( https://github.com/paulgb/runipy/pull/64 ).

Sends coverage statistics to [coveralls.io]( https://coveralls.io ) after running a build on Travis CI. This properly combines results from the matrix builds and shows which builds reach a line if only some of them do. Otherwise it marks uncovered lines red and covered lines green.