### PR TITLE
Better handle installation with iPython 4.x (Jupyter) in a backwards compatible way 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,18 +41,18 @@ install:
    - if [ -v IPYTHON_VERSION ]; then echo "ipython ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned ; fi
    - if [ -v IPYTHON_VERSION ]; then echo "ipython-notebook ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned ; fi
    - if [ -v IPYTHON_VERSION ]; then conda install ipython-notebook ; fi
-   # Install runipy.
-   - python setup.py install
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.
    - echo "coverage 3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install coverage
    - pip install coveralls
+   # Install runipy.
+   - coverage run -a setup.py install
    # Clean up downloads as there are quite a few and they waste space/memory.
    - conda clean -tipsy
    - rm -rfv $HOME/.cache/pip
 script:
    # Run tests.
-   - coverage run setup.py test --verbose
+   - coverage run -a setup.py test --verbose
    - coverage report
 # Use container format for TravisCI.
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: cpp
 env:
+   - PYTHON_VERSION="3.5"
+   - PYTHON_VERSION="3.4"
+   - PYTHON_VERSION="2.7"
    - PYTHON_VERSION="3.5" IPYTHON_VERSION=4
    - PYTHON_VERSION="3.4" IPYTHON_VERSION=4
    - PYTHON_VERSION="2.7" IPYTHON_VERSION=4
@@ -35,9 +38,9 @@ install:
    # Install dependencies.
    - touch $HOME/miniconda/envs/testenv/conda-meta/pinned
    - echo "python ${PYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
-   - echo "ipython ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
-   - echo "ipython-notebook ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
-   - conda install ipython-notebook
+   - if [ -v IPYTHON_VERSION ]; then echo "ipython ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned ; fi
+   - if [ -v IPYTHON_VERSION ]; then echo "ipython-notebook ${IPYTHON_VERSION}.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned ; fi
+   - if [ -v IPYTHON_VERSION ]; then conda install ipython-notebook ; fi
    # Install runipy.
    - python setup.py install
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,15 @@ from setuptools import setup
 import versioneer
 
 
+using_ipy4 = False
+try:
+    from IPython import __version__ as ipyv
+    from distutils.version import LooseVersion
+
+    using_ipy4 = (ipyv >= LooseVersion("4"))
+except ImportError:
+    using_ipy4 = True
+
 setup(name='runipy',
       version=versioneer.get_version(),
       description='Run IPython notebooks from the command line',

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,18 @@ try:
 except ImportError:
     using_ipy4 = True
 
+install_requires = [
+    'Jinja2>=2.7.2',
+    'Pygments>=1.6',
+    'ipython>=2.3.1',
+    'pyzmq>=14.1.0',
+]
+if using_ipy4:
+    install_requires.extend([
+        'ipykernel>=4.0.0',
+        'nbformat>=4.0.0',
+    ])
+
 setup(name='runipy',
       version=versioneer.get_version(),
       description='Run IPython notebooks from the command line',
@@ -21,12 +33,7 @@ setup(name='runipy',
       classifiers=[
           'Framework :: IPython',
       ],
-      install_requires=[
-          'Jinja2>=2.7.2',
-          'Pygments>=1.6',
-          'ipython>=2.3.1',
-          'pyzmq>=14.1.0',
-      ],
+      install_requires=install_requires,
       packages=['runipy'],
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
Fixes https://github.com/paulgb/runipy/issues/77

Checks for the iPython version in advance if there is one. If none is included or the version follows ["The Big Split"]( http://blog.jupyter.org/2015/04/15/the-big-split/ ), some missing install requirements that were broken out of iPython are added back in.