### PR TITLE
Ignore `coverage` `NoSource` errors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,5 +16,6 @@ omit =
     */python?.?/*
     */site-packages/*
     *tests/*
+    /tmp/*
     */versioneer.py
     */_version.py


### PR DESCRIPTION
Sometimes `coverage` generates `NoSource` errors in regards to code unrelated to the project (of dependencies). This should suppress those errors.

The errors tend to show up when `ipython` is installed via `pip`/`setuptools` into the `conda` environment as opposed to being installed via `conda`.