### PR TITLE
Add coverage in the test suite for `runipy.main`

### DIFF
--- a/test_runipy.py
+++ b/test_runipy.py
@@ -4,6 +4,7 @@ import unittest
 from glob import glob
 from os import path
 import re
+import sys
 
 try:
     # IPython 3
@@ -12,6 +13,7 @@ except ImportError:
     # IPython 2
     from IPython.nbformat.current import reads, NBFormatError
 
+from runipy.main import main
 from runipy.notebook_runner import NotebookRunner
 
 
@@ -86,6 +88,40 @@ class TestRunipy(unittest.TestCase):
                 # IPython 2
                 expected = reads(expected, 'json')
             self.assert_notebooks_equal(expected, runner.nb)
+
+    def testCLI(self):
+        notebook_dir = path.join('tests', 'expected')
+        for notebook_path in glob(path.join(notebook_dir, '*.ipynb')):
+            notebook_file = path.basename(notebook_path)
+            print(notebook_file)
+            expected = ""
+            with open(notebook_path) as notebook_file:
+                expected = notebook_file.read()
+            try:
+                # IPython 3
+                expected = reads(expected, 3)
+            except (TypeError, NBFormatError):
+                # IPython 2
+                expected = reads(expected, 'json')
+            exit_code = 1
+            argv = sys.argv
+            try:
+                sys.argv = ["runipy", "-o", notebook_path]
+                main()
+            except SystemExit as e:
+                exit_code = e.code
+            finally:
+                sys.argv = argv
+            notebook = ""
+            with open(notebook_path) as notebook_file:
+                notebook = notebook_file.read()
+            try:
+                # IPython 3
+                notebook = reads(notebook, 3)
+            except (TypeError, NBFormatError):
+                # IPython 2
+                notebook = reads(notebook, 'json')
+            self.assert_notebooks_equal(expected, notebook)
 
 
 if __name__ == '__main__':

--- a/test_runipy.py
+++ b/test_runipy.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import unittest
 from glob import glob
-from os import path
+from os import devnull, path
 import re
 import sys
 
@@ -105,13 +105,19 @@ class TestRunipy(unittest.TestCase):
                 expected = reads(expected, 'json')
             exit_code = 1
             argv = sys.argv
+            stdout = sys.stdout
+            stderr = sys.stderr
             try:
-                sys.argv = ["runipy", "-o", notebook_path]
-                main()
+                with open(devnull, "w") as devnull_filehandle:
+                    sys.stdout = sys.stderr = devnull_filehandle
+                    sys.argv = ["runipy", "-o", notebook_path]
+                    main()
             except SystemExit as e:
                 exit_code = e.code
             finally:
                 sys.argv = argv
+                sys.stdout = stdout
+                sys.stderr = stderr
             notebook = ""
             with open(notebook_path) as notebook_file:
                 notebook = notebook_file.read()


### PR DESCRIPTION
Tries to measure test coverage over `runipy.main`. Added some tests for running with CLI as part of the test suite. As a consequence, some incompatibilities were found, which needed fixing some of them are addressed. Currently, iPython 2.x supported is broken. This will result in a drop of coverage even when fixed so that should not be a blocker.