### PR TITLE
Handles a bug where the iPython 2 fallback does not work correctly

### DIFF
--- a/test_runipy.py
+++ b/test_runipy.py
@@ -7,10 +7,10 @@ import re
 
 try:
     # IPython 3
-    from IPython.nbformat import read, NBFormatError
+    from IPython.nbformat import reads, NBFormatError
 except ImportError:
     # IPython 2
-    from IPython.nbformat.current import read, NBFormatError
+    from IPython.nbformat.current import reads, NBFormatError
 
 from runipy.notebook_runner import NotebookRunner
 
@@ -66,25 +66,25 @@ class TestRunipy(unittest.TestCase):
             print(notebook_file)
             expected_file = path.join('tests', 'expected', notebook_file)
             notebook = ""
+            with open(notebook_path) as notebook_file:
+                notebook = notebook_file.read()
             try:
                 # IPython 3
-                with open(notebook_path) as notebook_file:
-                    notebook = read(notebook_file, 3)
+                notebook = reads(notebook, 3)
             except (TypeError, NBFormatError):
                 # IPython 2
-                with open(notebook_path) as notebook_file:
-                    notebook = read(notebook_file, 'json')
+                notebook = reads(notebook, 'json')
             runner = NotebookRunner(notebook, working_dir=notebook_dir)
             runner.run_notebook(True)
             expected = ""
+            with open(expected_file) as notebook_file:
+                expected = notebook_file.read()
             try:
                 # IPython 3
-                with open(expected_file) as notebook_file:
-                    expected = read(notebook_file, 3)
+                expected = reads(expected, 3)
             except (TypeError, NBFormatError):
                 # IPython 2
-                with open(expected_file) as notebook_file:
-                    expected = read(notebook_file, 'json')
+                expected = reads(expected, 'json')
             self.assert_notebooks_equal(expected, runner.nb)
 
 


### PR DESCRIPTION
As the previous strategy was to read from the notebook from the file handle, it was not possible to perform a second read when the v3 format failed and a fallback was used by iPython 2. Thus, this resulted in an empty string being read when iPython 2 tried to serializing the notebook. This fixes that problem by reading the file or `stdin` in advance as a `str`. As a result, we can simply use `IPython.nbformat.reads` to construct the notebook from a `str`.