### PR TITLE
Fix iPython 4.x `ShimWarning`

### DIFF
--- a/runipy/main.py
+++ b/runipy/main.py
@@ -15,6 +15,7 @@ with warnings.catch_warnings():
         warnings.filterwarnings('error', '', ShimWarning)
     except ImportError:
         class ShimWarning(Warning):
+            """Warning issued by iPython 4.x regarding deprecated API."""
             pass
 
     try:

--- a/runipy/main.py
+++ b/runipy/main.py
@@ -26,6 +26,8 @@ with warnings.catch_warnings():
         from IPython.config import Config
         from IPython.nbconvert.exporters.html import HTMLExporter
         from IPython.nbformat.current import reads, write, NBFormatError
+    finally:
+        warnings.resetwarnings()
 
 
 def main():

--- a/runipy/main.py
+++ b/runipy/main.py
@@ -14,14 +14,15 @@ with warnings.catch_warnings():
         from IPython.utils.shimmodule import ShimWarning
         warnings.filterwarnings('error', '', ShimWarning)
     except ImportError:
-        pass
+        class ShimWarning(Warning):
+            pass
 
     try:
         # IPython 3
         from IPython.config import Config
         from IPython.nbconvert.exporters.html import HTMLExporter
         from IPython.nbformat import reads, write, NBFormatError
-    except Warning:
+    except ShimWarning:
         # IPython 4
         from traitlets.config import Config
         from nbconvert.exporters.html import HTMLExporter

--- a/runipy/main.py
+++ b/runipy/main.py
@@ -5,15 +5,21 @@ from sys import stderr, stdout, stdin, exit
 import os.path
 import logging
 import codecs
+import warnings
 import runipy
 
 from runipy.notebook_runner import NotebookRunner, NotebookError
-try:
-    # IPython 3
-    from IPython.nbformat import reads, write, NBFormatError
-except ImportError:
-    # IPython 2
-    from IPython.nbformat.current import reads, write, NBFormatError
+with warnings.catch_warnings():
+    warnings.filterwarnings('error')
+    try:
+        # IPython 3
+        from IPython.nbformat import reads, write, NBFormatError
+    except Warning:
+        # IPython 4
+        from nbformat import reads, write, NBFormatError
+    except ImportError:
+        # IPython 2
+        from IPython.nbformat.current import reads, write, NBFormatError
 
 from IPython.config import Config
 from IPython.nbconvert.exporters.html import HTMLExporter

--- a/runipy/main.py
+++ b/runipy/main.py
@@ -14,17 +14,18 @@ with warnings.catch_warnings():
     try:
         # IPython 3
         from IPython.config import Config
+        from IPython.nbconvert.exporters.html import HTMLExporter
         from IPython.nbformat import reads, write, NBFormatError
     except Warning:
         # IPython 4
         from traitlets.config import Config
+        from nbconvert.exporters.html import HTMLExporter
         from nbformat import reads, write, NBFormatError
     except ImportError:
         # IPython 2
         from IPython.config import Config
+        from IPython.nbconvert.exporters.html import HTMLExporter
         from IPython.nbformat.current import reads, write, NBFormatError
-
-from IPython.nbconvert.exporters.html import HTMLExporter
 
 
 def main():

--- a/runipy/main.py
+++ b/runipy/main.py
@@ -13,15 +13,17 @@ with warnings.catch_warnings():
     warnings.filterwarnings('error')
     try:
         # IPython 3
+        from IPython.config import Config
         from IPython.nbformat import reads, write, NBFormatError
     except Warning:
         # IPython 4
+        from traitlets.config import Config
         from nbformat import reads, write, NBFormatError
     except ImportError:
         # IPython 2
+        from IPython.config import Config
         from IPython.nbformat.current import reads, write, NBFormatError
 
-from IPython.config import Config
 from IPython.nbconvert.exporters.html import HTMLExporter
 
 

--- a/runipy/main.py
+++ b/runipy/main.py
@@ -10,7 +10,12 @@ import runipy
 
 from runipy.notebook_runner import NotebookRunner, NotebookError
 with warnings.catch_warnings():
-    warnings.filterwarnings('error')
+    try:
+        from IPython.utils.shimmodule import ShimWarning
+        warnings.filterwarnings('error', '', ShimWarning)
+    except ImportError:
+        pass
+
     try:
         # IPython 3
         from IPython.config import Config

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -18,13 +18,14 @@ with warnings.catch_warnings():
         from IPython.utils.shimmodule import ShimWarning
         warnings.filterwarnings('error', '', ShimWarning)
     except ImportError:
-        pass
+        class ShimWarning(Warning):
+            pass
 
     try:
         # IPython 3
         from IPython.kernel import KernelManager
         from IPython.nbformat import NotebookNode
-    except Warning:
+    except ShimWarning:
         # IPython 4
         from nbformat import NotebookNode
         from jupyter_client import KernelManager

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -11,13 +11,19 @@ import platform
 from time import sleep
 import logging
 import os
+import warnings
 
-try:
-    # IPython 3
-    from IPython.nbformat import NotebookNode
-except ImportError:
-    # IPython 2
-    from IPython.nbformat.current import NotebookNode
+with warnings.catch_warnings():
+    warnings.filterwarnings('error')
+    try:
+        # IPython 3
+        from IPython.nbformat import NotebookNode
+    except Warning:
+        # IPython 4
+        from nbformat import NotebookNode
+    except ImportError:
+        # IPython 2
+        from IPython.nbformat.current import NotebookNode
 from IPython.kernel import KernelManager
 
 

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -27,6 +27,8 @@ with warnings.catch_warnings():
         # IPython 2
         from IPython.kernel import KernelManager
         from IPython.nbformat.current import NotebookNode
+    finally:
+        warnings.resetwarnings()
 
 
 class NotebookError(Exception):

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -17,14 +17,16 @@ with warnings.catch_warnings():
     warnings.filterwarnings('error')
     try:
         # IPython 3
+        from IPython.kernel import KernelManager
         from IPython.nbformat import NotebookNode
     except Warning:
         # IPython 4
         from nbformat import NotebookNode
+        from jupyter_client import KernelManager
     except ImportError:
         # IPython 2
+        from IPython.kernel import KernelManager
         from IPython.nbformat.current import NotebookNode
-from IPython.kernel import KernelManager
 
 
 class NotebookError(Exception):

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -16,6 +16,7 @@ try:
     # IPython 3
     from IPython.nbformat import NotebookNode
 except ImportError:
+    # IPython 2
     from IPython.nbformat.current import NotebookNode
 from IPython.kernel import KernelManager
 

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -19,6 +19,7 @@ with warnings.catch_warnings():
         warnings.filterwarnings('error', '', ShimWarning)
     except ImportError:
         class ShimWarning(Warning):
+            """Warning issued by iPython 4.x regarding deprecated API."""
             pass
 
     try:

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -14,7 +14,12 @@ import os
 import warnings
 
 with warnings.catch_warnings():
-    warnings.filterwarnings('error')
+    try:
+        from IPython.utils.shimmodule import ShimWarning
+        warnings.filterwarnings('error', '', ShimWarning)
+    except ImportError:
+        pass
+
     try:
         # IPython 3
         from IPython.kernel import KernelManager

--- a/test_runipy.py
+++ b/test_runipy.py
@@ -12,12 +12,13 @@ with warnings.catch_warnings():
         from IPython.utils.shimmodule import ShimWarning
         warnings.filterwarnings('error', '', ShimWarning)
     except ImportError:
-        pass
+        class ShimWarning(Warning):
+            pass
 
     try:
         # IPython 3
         from IPython.nbformat import reads, NBFormatError
-    except Warning:
+    except ShimWarning:
         # IPython 4
         from nbformat import reads, NBFormatError
     except ImportError:

--- a/test_runipy.py
+++ b/test_runipy.py
@@ -13,6 +13,7 @@ with warnings.catch_warnings():
         warnings.filterwarnings('error', '', ShimWarning)
     except ImportError:
         class ShimWarning(Warning):
+            """Warning issued by iPython 4.x regarding deprecated API."""
             pass
 
     try:

--- a/test_runipy.py
+++ b/test_runipy.py
@@ -5,13 +5,19 @@ from glob import glob
 from os import devnull, path
 import re
 import sys
+import warnings
 
-try:
-    # IPython 3
-    from IPython.nbformat import reads, NBFormatError
-except ImportError:
-    # IPython 2
-    from IPython.nbformat.current import reads, NBFormatError
+with warnings.catch_warnings():
+    warnings.filterwarnings('error')
+    try:
+        # IPython 3
+        from IPython.nbformat import reads, NBFormatError
+    except Warning:
+        # IPython 4
+        from nbformat import reads, NBFormatError
+    except ImportError:
+        # IPython 2
+        from IPython.nbformat.current import reads, NBFormatError
 
 from runipy.main import main
 from runipy.notebook_runner import NotebookRunner

--- a/test_runipy.py
+++ b/test_runipy.py
@@ -18,6 +18,8 @@ with warnings.catch_warnings():
     except ImportError:
         # IPython 2
         from IPython.nbformat.current import reads, NBFormatError
+    finally:
+        warnings.resetwarnings()
 
 from runipy.main import main
 from runipy.notebook_runner import NotebookRunner

--- a/test_runipy.py
+++ b/test_runipy.py
@@ -8,7 +8,12 @@ import sys
 import warnings
 
 with warnings.catch_warnings():
-    warnings.filterwarnings('error')
+    try:
+        from IPython.utils.shimmodule import ShimWarning
+        warnings.filterwarnings('error', '', ShimWarning)
+    except ImportError:
+        pass
+
     try:
         # IPython 3
         from IPython.nbformat import reads, NBFormatError


### PR DESCRIPTION
Fixes https://github.com/paulgb/runipy/issues/95

In iPython 4.x, the API has changed regarding what modules contain relevant import items. Up to now, we have been using the iPython 3.x API to handle these imports. This works; however, it results in many log messages regarding how this API is deprecated and calls this a `ShimWarning`. This makes it hard to read output from `runipy`. This PR handles these warnings, as exceptions, to ensure the proper import strategy is used thus avoiding these warnings.