### PR TITLE
Fix converting output to HTML

### DIFF
--- a/runipy/main.py
+++ b/runipy/main.py
@@ -204,7 +204,9 @@ def main():
             )
 
         logging.info('Saving HTML snapshot to %s' % args.html)
-        output, resources = exporter.from_notebook_node(nb_runner.nb)
+        output, resources = exporter.from_notebook_node(
+            convert(nb_runner.nb, current_nbformat)
+        )
         codecs.open(args.html, 'w', encoding='utf-8').write(output)
 
     nb_runner.shutdown_kernel()

--- a/runipy/main.py
+++ b/runipy/main.py
@@ -22,17 +22,20 @@ with warnings.catch_warnings():
         # IPython 3
         from IPython.config import Config
         from IPython.nbconvert.exporters.html import HTMLExporter
-        from IPython.nbformat import reads, write, NBFormatError
+        from IPython.nbformat import \
+            convert, current_nbformat, reads, write, NBFormatError
     except ShimWarning:
         # IPython 4
         from traitlets.config import Config
         from nbconvert.exporters.html import HTMLExporter
-        from nbformat import reads, write, NBFormatError
+        from nbformat import \
+            convert, current_nbformat, reads, write, NBFormatError
     except ImportError:
         # IPython 2
         from IPython.config import Config
         from IPython.nbconvert.exporters.html import HTMLExporter
-        from IPython.nbformat.current import reads, write, NBFormatError
+        from IPython.nbformat.current import \
+            convert, current_nbformat, reads, write, NBFormatError
     finally:
         warnings.resetwarnings()
 

--- a/test_runipy.py
+++ b/test_runipy.py
@@ -130,7 +130,11 @@ class TestRunipy(unittest.TestCase):
             try:
                 with open(devnull, "w") as devnull_filehandle:
                     sys.stdout = sys.stderr = devnull_filehandle
-                    sys.argv = ["runipy", "-o", notebook_path]
+                    sys.argv = [
+                        "runipy",
+                        "-o", notebook_path,
+                        "--html", notebook_path.replace(".ipynb", ".html")
+                    ]
                     main()
             except SystemExit as e:
                 exit_code = e.code


### PR DESCRIPTION
Fixes https://github.com/paulgb/runipy/issues/58
Closes https://github.com/paulgb/runipy/pull/99
Closes https://github.com/paulgb/runipy/pull/100

This attempts to convert the iPython notebook to the latest version before sending it to be converted to HTML. This is done as iPython is unable to handle old versions of the notebook going in to the HTML exporter. However, if it is using the latest format of the notebook available, this should not be an issue.