### PR TITLE
Allow different kernels

### DIFF
--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -63,8 +63,9 @@ class NotebookRunner(object):
             pylab=False,
             mpl_inline=False,
             profile_dir=None,
-            working_dir=None):
-        self.km = KernelManager()
+            working_dir=None,
+            kernel_name='python'):
+        self.km = KernelManager(kernel_name=kernel_name)
 
         args = []
 


### PR DESCRIPTION
Fixes https://github.com/paulgb/runipy/issues/16

Uses the API in iPython 3 and 4 to allow for this. May require a backport for iPython 2.
