### PR TITLE
Support json outputs

### DIFF
--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -38,6 +38,8 @@ with warnings.catch_warnings():
     finally:
         warnings.resetwarnings()
 
+import IPython
+
 
 class NotebookError(Exception):
     pass
@@ -197,13 +199,14 @@ class NotebookRunner(object):
                             'unhandled mime type: %s' % mime
                         )
                     
-                    # json data is stored as a string
-                    if mime == "application/json":
-                        data_out = json.dumps(data)
+                    # In notebook version <= 3 JSON data is stored as a string
+                    # Evaluation of IPython2's JSON gives strings directly
+                    # Therefore do not encode for IPython versions prior to 3
+                    json_encode = (
+                            IPython.version_info[0] >= 3 and 
+                            mime == "application/json")
 
-                    else:
-                        data_out = data
-
+                    data_out = data if not json_encode else json.dumps(data)
                     setattr(out, attr, data_out)
             elif msg_type == 'pyerr':
                 out.ename = content['ename']

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -9,6 +9,7 @@ except ImportError:
 
 import platform
 from time import sleep
+import json
 import logging
 import os
 import warnings
@@ -54,6 +55,7 @@ class NotebookRunner(object):
         'text/html': 'html',
         'text/latex': 'latex',
         'application/javascript': 'html',
+        'application/json': 'json',
         'image/svg+xml': 'svg',
     }
 
@@ -194,8 +196,15 @@ class NotebookRunner(object):
                         raise NotImplementedError(
                             'unhandled mime type: %s' % mime
                         )
+                    
+                    # json data is stored as a string
+                    if mime == "application/json":
+                        data_out = json.dumps(data)
 
-                    setattr(out, attr, data)
+                    else:
+                        data_out = data
+
+                    setattr(out, attr, data_out)
             elif msg_type == 'pyerr':
                 out.ename = content['ename']
                 out.evalue = content['evalue']

--- a/tests/expected/JSON.ipynb
+++ b/tests/expected/JSON.ipynb
@@ -1,0 +1,46 @@
+{
+ "metadata": {
+  "name": ""
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "from IPython.core.display import JSON\n",
+      "JSON({\"foo\": \"bar\"})"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "json": [
+        "{\"foo\": \"bar\"}"
+       ],
+       "output_type": "pyout",
+       "prompt_number": 1,
+       "text": [
+        "<IPython.core.display.JSON object>"
+       ]
+      }
+     ],
+     "prompt_number": 1
+    },
+    {
+     "cell_type": "code",
+     "collapsed": true,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 2
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/tests/expected/JSON.ipynb
+++ b/tests/expected/JSON.ipynb
@@ -11,8 +11,12 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
+      "import IPython\n",
       "from IPython.core.display import JSON\n",
-      "JSON({\"foo\": \"bar\"})"
+      "import json\n",
+      "\n",
+      "d = {\"foo\": \"bar\"}\n",
+      "JSON(d if IPython.version_info[0] >= 3 else json.dumps(d))"
      ],
      "language": "python",
      "metadata": {},

--- a/tests/input/JSON.ipynb
+++ b/tests/input/JSON.ipynb
@@ -1,0 +1,35 @@
+{
+ "metadata": {
+  "name": ""
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "from IPython.core.display import JSON\n",
+      "JSON({\"foo\": \"bar\"})"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "code",
+     "collapsed": true,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/tests/input/JSON.ipynb
+++ b/tests/input/JSON.ipynb
@@ -11,8 +11,12 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
+      "import IPython\n",
       "from IPython.core.display import JSON\n",
-      "JSON({\"foo\": \"bar\"})"
+      "import json\n",
+      "\n",
+      "d = {\"foo\": \"bar\"}\n",
+      "JSON(d if IPython.version_info[0] >= 3 else json.dumps(d))"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
IPython allows to add arbitrary JSON data as output. This pull request adds support to runipy for this output type. It contains corresponding notebooks in the test directories to illustrate the changes. 