### PR TITLE
Allow customizing the output notebook version

### DIFF
--- a/runipy/main.py
+++ b/runipy/main.py
@@ -103,6 +103,12 @@ def main():
         '--profile-dir',
         help="set the profile location directly"
     )
+    parser.add_argument(
+        '--output-nbformat-version',
+        help='nbformat major version to write output in',
+        default=3,
+        type=int
+    )
     args = parser.parse_args()
 
     if args.overwrite:
@@ -166,8 +172,8 @@ def main():
         logging.info('Saving to %s', args.output_file)
         with open(args.output_file, 'w') as output_filehandle:
             try:
-                # Ipython 3
-                write(nb_runner.nb, output_filehandle, 3)
+                # Ipython 3/4
+                write(nb_runner.nb, output_filehandle, args.output_nbformat_version)
             except (TypeError, NBFormatError):
                 # Ipython 2
                 write(nb_runner.nb, output_filehandle, 'json')
@@ -175,7 +181,7 @@ def main():
     if args.stdout or args.output_file == '-':
         try:
             # Ipython 3
-            write(nb_runner.nb, stdout, 3)
+            write(nb_runner.nb, stdout, args.output_nbformat_version)
         except (TypeError, NBFormatError):
             # Ipython 2
             write(nb_runner.nb, stdout, 'json')


### PR DESCRIPTION
Defaults to 3, since that's the current default. Writing to
v2 requires that you use ipython 2 install, and ignores the
command line parameter

Fixes some form of #102, since it can output v4 notebooks.
