### PR TITLE
Add deprecation warning for IPython 2.x and v2 notebook support

### DIFF
--- a/runipy/main.py
+++ b/runipy/main.py
@@ -23,19 +23,13 @@ with warnings.catch_warnings():
         from IPython.config import Config
         from IPython.nbconvert.exporters.html import HTMLExporter
         from IPython.nbformat import \
-            convert, current_nbformat, reads, write, NBFormatError
+            convert, current_nbformat, reads, write
     except ShimWarning:
         # IPython 4
         from traitlets.config import Config
         from nbconvert.exporters.html import HTMLExporter
         from nbformat import \
-            convert, current_nbformat, reads, write, NBFormatError
-    except ImportError:
-        # IPython 2
-        from IPython.config import Config
-        from IPython.nbconvert.exporters.html import HTMLExporter
-        from IPython.nbformat.current import \
-            convert, current_nbformat, reads, write, NBFormatError
+            convert, current_nbformat, reads, write
     finally:
         warnings.resetwarnings()
 
@@ -152,12 +146,8 @@ def main():
         profile_dir = None
 
     logging.info('Reading notebook %s', payload_source)
-    try:
-        # Ipython 3
-        nb = reads(payload, 3)
-    except (TypeError, NBFormatError):
-        # Ipython 2
-        nb = reads(payload, 'json')
+    # Ipython 3/4
+    nb = reads(payload, 3)
     nb_runner = NotebookRunner(
         nb, args.pylab, args.matplotlib, profile_dir, working_dir
     )
@@ -171,20 +161,11 @@ def main():
     if args.output_file and args.output_file != '-':
         logging.info('Saving to %s', args.output_file)
         with open(args.output_file, 'w') as output_filehandle:
-            try:
-                # Ipython 3/4
-                write(nb_runner.nb, output_filehandle, args.output_nbformat_version)
-            except (TypeError, NBFormatError):
-                # Ipython 2
-                write(nb_runner.nb, output_filehandle, 'json')
+            # Ipython 3/4
+            write(nb_runner.nb, output_filehandle, args.output_nbformat_version)
 
     if args.stdout or args.output_file == '-':
-        try:
-            # Ipython 3
-            write(nb_runner.nb, stdout, args.output_nbformat_version)
-        except (TypeError, NBFormatError):
-            # Ipython 2
-            write(nb_runner.nb, stdout, 'json')
+        write(nb_runner.nb, stdout, args.output_nbformat_version)
         print()
 
     if args.html is not False:

--- a/runipy/main.py
+++ b/runipy/main.py
@@ -103,6 +103,12 @@ def main():
         '--profile-dir',
         help="set the profile location directly"
     )
+    parser.add_argument(
+        '--output-nbformat-version',
+        help='nbformat major version to write output in',
+        default=3,
+        type=int
+    )
     args = parser.parse_args()
 
     if args.overwrite:
@@ -166,8 +172,8 @@ def main():
         logging.info('Saving to %s', args.output_file)
         with open(args.output_file, 'w') as output_filehandle:
             try:
-                # Ipython 3
-                write(nb_runner.nb, output_filehandle, 3)
+                # Ipython 3/4
+                write(nb_runner.nb, output_filehandle, args.output_nbformat_version)
             except (TypeError, NBFormatError):
                 # Ipython 2
                 write(nb_runner.nb, output_filehandle, 'json')
@@ -175,7 +181,7 @@ def main():
     if args.stdout or args.output_file == '-':
         try:
             # Ipython 3
-            write(nb_runner.nb, stdout, 3)
+            write(nb_runner.nb, stdout, args.output_nbformat_version)
         except (TypeError, NBFormatError):
             # Ipython 2
             write(nb_runner.nb, stdout, 'json')

--- a/runipy/notebook_runner.py
+++ b/runipy/notebook_runner.py
@@ -30,10 +30,6 @@ with warnings.catch_warnings():
         # IPython 4
         from nbformat import NotebookNode
         from jupyter_client import KernelManager
-    except ImportError:
-        # IPython 2
-        from IPython.kernel import KernelManager
-        from IPython.nbformat.current import NotebookNode
     finally:
         warnings.resetwarnings()
 


### PR DESCRIPTION
Partial fix for #78.

If ok, I'll probably make changes to have this natively read / operate on v4 notebooks and convert v3 notebooks on input/output (vs now, where it operates on v3 natively and converts to v4 on input/output)
