### PR TITLE
WIP: Add iPython compatibility module

### DIFF
--- a/runipy/ipycompat.py
+++ b/runipy/ipycompat.py
@@ -1,0 +1,32 @@
+with warnings.catch_warnings():
+    try:
+        from IPython.utils.shimmodule import ShimWarning
+        warnings.filterwarnings('error', '', ShimWarning)
+    except ImportError:
+        class ShimWarning(Warning):
+            """Warning issued by IPython 4.x regarding deprecated API."""
+            pass
+
+    try:
+        # IPython 3
+        from IPython.config import Config
+        from IPython.kernel import KernelManager
+        from IPython.nbconvert.exporters.html import HTMLExporter
+        from IPython.nbformat import \
+            convert, current_nbformat, reads, write, NBFormatError, NotebookNode
+    except ShimWarning:
+        # IPython 4
+        from traitlets.config import Config
+        from jupyter_client import KernelManager
+        from nbconvert.exporters.html import HTMLExporter
+        from nbformat import \
+            convert, current_nbformat, reads, write, NBFormatError, NotebookNode
+    except ImportError:
+        # IPython 2
+        from IPython.config import Config
+        from IPython.kernel import KernelManager
+        from IPython.nbconvert.exporters.html import HTMLExporter
+        from IPython.nbformat.current import \
+            convert, current_nbformat, reads, write, NBFormatError, NotebookNode
+    finally:
+        warnings.resetwarnings()


### PR DESCRIPTION
This is a module created for handling iPython compatibility between the different iPython versions. As we support 2.x, 3.x, and 4.x, the code has become a lot messier and harder to follow as there are lots of special cases for each of these. This PR will provide these in a separate `ipycompat` module (may later become a package) that will allow us to ignore most if not all the differences.
