### PR TITLE
Drop Python 3 check for miniconda download URL.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
    - pwd
 install:
    # Download and configure conda.
-   - wget http://repo.continuum.io/miniconda/Miniconda`echo ${PYTHON_VERSION:0:1} | grep 3`-latest-Linux-x86_64.sh -O miniconda.sh
+   - wget http://repo.continuum.io/miniconda/Miniconda`echo ${PYTHON_VERSION:0:1}`-latest-Linux-x86_64.sh -O miniconda.sh
    - bash miniconda.sh -b -p $HOME/miniconda
    - export PATH="$HOME/miniconda/bin:$PATH"
    - conda config --set always_yes yes


### PR DESCRIPTION
As `Miniconda2-latest-Linux-x86_64.sh` is provided for (with the 2), there is no need to strip the 2 for installation of Python 2 in miniconda's root.