### PR TITLE
Add Anaconda badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Travis Build Status| |Coveralls| |License| |PyPI| |Gitter|
+|Travis Build Status| |Coveralls| |License| |PyPI| |Anaconda| |Gitter|
 
 --------------
 
@@ -140,6 +140,9 @@ for patches, documentation fixes, and suggestions.
 
 .. |PyPI| image:: https://img.shields.io/pypi/v/runipy.svg
    :target: https://pypi.python.org/pypi/runipy
+
+.. |Anaconda| image:: https://anaconda.org/conda-forge/runipy/badges/version.svg
+   :target: https://anaconda.org/conda-forge/runipy
 
 .. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
    :alt: Join the chat at https://gitter.im/paulgb/runipy

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Travis Build Status| |Coveralls| |License| |Version| |Gitter|
+|Travis Build Status| |Coveralls| |License| |PyPI| |Gitter|
 
 --------------
 
@@ -138,7 +138,7 @@ for patches, documentation fixes, and suggestions.
    :alt: BSD License
    :target: https://raw.githubusercontent.com/paulgb/runipy/master/LICENSE
 
-.. |Version| image:: https://img.shields.io/pypi/v/runipy.svg
+.. |PyPI| image:: https://img.shields.io/pypi/v/runipy.svg
    :target: https://pypi.python.org/pypi/runipy
 
 .. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg


### PR DESCRIPTION
Adds a badge for Anaconda. Points to the package [package]( https://anaconda.org/conda-forge/runipy ) from [conda-forge]( https://conda-forge.github.io/ ) on [Anaconda.org]( https://anaconda.org/ ).