### PR TITLE
Fix up some CI build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ install:
    # Install `entrypoints` first as a workaround for an install issue with `pip`.
    # See issue ( https://github.com/paulgb/runipy/issues/123 ) for details.
    - if [ ! -v IPYTHON_VERSION ]; then pip install entrypoints; fi
+   # Install `backports.shutil_get_terminal_size` first as a workaround for an install issue with `pip`.
+   # See issue ( https://github.com/paulgb/runipy/issues/123 ) for details.
+   - if ( [ ! -v IPYTHON_VERSION ] && [ "${PYTHON_VERSION}" == "2.7" ] ); then pip install backports.shutil_get_terminal_size; fi
    # Install runipy.
    - coverage run -a setup.py install
    # Install linting tools.

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,13 @@ before_install:
    - pwd
 install:
    # Download and configure conda.
-   - wget http://repo.continuum.io/miniconda/Miniconda`echo ${PYTHON_VERSION:0:1}`-latest-Linux-x86_64.sh -O miniconda.sh
+   - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
    - bash miniconda.sh -b -p $HOME/miniconda
    - export PATH="$HOME/miniconda/bin:$PATH"
    - conda config --set always_yes yes
    - conda config --set show_channel_urls True
    - source activate root
    - conda update --all
-   # Fix root environment to have the correct Python version.
-   - touch $HOME/miniconda/conda-meta/pinned
-   - echo "python ${PYTHON_VERSION}.*" >> $HOME/miniconda/conda-meta/pinned
-   - conda install python=$PYTHON_VERSION
    # Build the conda package for runipy.
    - cd $TRAVIS_REPO_SLUG
    - VERSION=`python setup.py --version`

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ install:
    - echo "coverage 3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install coverage
    - pip install coveralls
+   # Install entrypoints first as a workaround for an install issue with `pip`.
+   # See issue ( https://github.com/paulgb/runipy/issues/123 ) for details.
+   - if [ ! -v IPYTHON_VERSION ]; then pip install entrypoints; fi
    # Install runipy.
    - coverage run -a setup.py install
    # Install linting tools.

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
    - echo "coverage 3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install coverage
    - pip install coveralls
-   # Install entrypoints first as a workaround for an install issue with `pip`.
+   # Install `entrypoints` first as a workaround for an install issue with `pip`.
    # See issue ( https://github.com/paulgb/runipy/issues/123 ) for details.
    - if [ ! -v IPYTHON_VERSION ]; then pip install entrypoints; fi
    # Install runipy.


### PR DESCRIPTION
Closes https://github.com/paulgb/runipy/issues/123

* Install `entrypoints` beforehand to workaround a pip install issue ( https://github.com/paulgb/runipy/issues/123 ).
* Install `backports.shutil_get_terminal_size` beforehand to workaround a pip install issue ( https://github.com/paulgb/runipy/issues/123 ).
* Simply use the latest Python 3 Miniconda environment available for all testing.